### PR TITLE
ヒント表示をカスタムフック化

### DIFF
--- a/frontend/src/components/HintSection.tsx
+++ b/frontend/src/components/HintSection.tsx
@@ -1,13 +1,14 @@
-import { useState } from 'react';
 import { Button, Box } from '@chakra-ui/react';
 import Hint from './Hint';
+import { useShowHint } from '../hooks/useShowHint';
 
 type Props = {
   hint: string;
+  questionId: number;
 };
 
-const HintSection: React.FC<Props> = ({ hint }) => {
-  const [showHint, setShowHint] = useState(false);
+const HintSection: React.FC<Props> = ({ hint, questionId }) => {
+  const [showHint, setShowHint] = useShowHint(false, questionId);
 
   return (
     <Box mt={6} w="100%">

--- a/frontend/src/container/QuestionContainer.tsx
+++ b/frontend/src/container/QuestionContainer.tsx
@@ -47,7 +47,7 @@ const QuestionContainer: React.FC<FetchQuestionsParams> = ({categoryId, limit}) 
       />
       <QuestionText id={question.id} text={question.questionText} />
       <ChoiceList choices={question.choices} isSelectable onSelect={handleSelect} />
-      <HintSection hint={question.hint} />
+      <HintSection hint={question.hint} questionId={question.id} />
     </>
   );
 };

--- a/frontend/src/hooks/useShowHint.ts
+++ b/frontend/src/hooks/useShowHint.ts
@@ -1,0 +1,11 @@
+import { useState, useEffect } from 'react';
+
+export function useShowHint<T>(initialValue: T, questionId: number) {
+  const [showHint, setShowHint] = useState<T>(initialValue);
+
+  useEffect(() => {
+    setShowHint(initialValue);
+  }, [questionId]);
+
+  return [showHint, setShowHint] as const;
+}


### PR DESCRIPTION
ヒントを表示した後、次の問題に遷移したら表示しっぱなしになっていた→useEffectを使う＆カスタムフック化して解消